### PR TITLE
Update the nftables template for old version support.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -427,11 +427,12 @@ rmClientWGConfEntry() {
 
 addClientNATEntry() {
 	local line_n
-	line_n=$(grep -n "type nat hook prerouting" "${WG_CONF_FOLDER}/add-fullcone-nat.sh" | cut -d ':' -f '1')
-	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" udp dport {$CLIENT_FORWARD_PORTS} dnat ip6 to $CLIENT_WG_IPV6 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
-	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" tcp dport {$CLIENT_FORWARD_PORTS} dnat ip6 to $CLIENT_WG_IPV6 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
+	line_n=$(grep -n "WG_Installer_IP_Rule_Starts" "${WG_CONF_FOLDER}/add-fullcone-nat.sh" | cut -d ':' -f '1')
 	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" udp dport {$CLIENT_FORWARD_PORTS} dnat ip to $CLIENT_WG_IPV4 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
 	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" tcp dport {$CLIENT_FORWARD_PORTS} dnat ip to $CLIENT_WG_IPV4 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
+	line_n=$(grep -n "WG_Installer_IP6_Rule_Starts" "${WG_CONF_FOLDER}/add-fullcone-nat.sh" | cut -d ':' -f '1')
+	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" udp dport {$CLIENT_FORWARD_PORTS} dnat ip6 to $CLIENT_WG_IPV6 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
+	sudo sed -i "${line_n}a\        iifname \"$SERVER_PUB_NIC\" tcp dport {$CLIENT_FORWARD_PORTS} dnat ip6 to $CLIENT_WG_IPV6 comment \"WireGuardGamingInstaller_Client_${CLIENT_NAME}\"" "${WG_CONF_FOLDER}/add-fullcone-nat.sh"
 }
 
 rmClientNATEntry() {

--- a/templates/add-fullcone-nat.sh
+++ b/templates/add-fullcone-nat.sh
@@ -12,7 +12,7 @@ table inet filter {
     }
 }
 
-table inet nat {
+table ip nat {
     chain POSTROUTING {
         type nat hook postrouting priority srcnat; policy accept;
         oifname "$SERVER_PUB_NIC" counter masquerade comment "WireGuardGamingInstaller"
@@ -20,5 +20,18 @@ table inet nat {
 
     chain PREROUTING {
         type nat hook prerouting priority dstnat; policy accept;
+        # WG_Installer_IP_Rule_Starts (Do not remove)
+    }
+}
+
+table ip6 nat {
+    chain POSTROUTING {
+        type nat hook postrouting priority srcnat; policy accept;
+        oifname "$SERVER_PUB_NIC" counter masquerade comment "WireGuardGamingInstaller"
+    }
+
+    chain PREROUTING {
+        type nat hook prerouting priority dstnat; policy accept;
+        # WG_Installer_IP6_Rule_Starts (Do not remove)
     }
 }


### PR DESCRIPTION
Older version of nftables requires `nat` to be either under family `ip` or `ip6`, instead of `inet`.