### PR TITLE
Fixed issue #37.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ SCRIPT_ROOT_DIR=$(
 
 # Check whether userspace or kernel WireGuard
 checkVirt() {
-	OS_VIRT=$(systemd-detect-virt)
+	OS_VIRT=$(systemd-detect-virt || true)
 	USERSPACE_WG='false'
 
 	if [ "$OS_VIRT" = 'openvz' ]; then


### PR DESCRIPTION
## Issue
When the machine virtualization type is none, the `systemd-detect-virt` command exits with an error code 1, halting script execution.

## Resolution
Added `|| true` to the `systemd-detect-virt` command to ensure it always returns a successful exit code, preventing the script from stopping. The existing logic already handles the `none` virtualization type correctly, so no further changes are required.

